### PR TITLE
Allow user to customize trigger key combination

### DIFF
--- a/plugin/files/completion.js
+++ b/plugin/files/completion.js
@@ -304,7 +304,13 @@ Completion.prototype.handleKeydown = function(event) {
 Completion.prototype.handleInput = function(event) {
     this._hasInput = true;
     //DEBUG console.log( "__INPUT hasI="+this._hasInput );
-};	
+};
+
+Completion.prototype.isCompletionTriggered = function(event) {
+	let key = event.keyCode || event.which;
+	return key === 32 && event.ctrlKey && event.shiftKey;
+};
+	
 /**
  * Set _lastChar, detects CTRL+SPACE.
  */
@@ -319,7 +325,7 @@ Completion.prototype.handleKeypress = function(event) {
     //DEBUG this._logStatus( "KEYPRESS" );
     
     // Detect Ctrl+Space
-    if( key === 32 && event.ctrlKey && this._state === "VOID" ) {
+    if( this.isCompletionTriggered(event) && this._state === "VOID" ) {
 	//Find a proper Template
 	// first from which we can extract a pattern
 	if( this._template === undefined ) {

--- a/plugin/files/completion.js
+++ b/plugin/files/completion.js
@@ -50,7 +50,7 @@ TODO : CHECK if needed
 var getCaretCoordinates = require("$:/plugins/snowgoon88/edit-comptext/cursor-position.js");
 
 /** Default Completion Attributes */
-var DEFATT = { maxMatch: 5, minPatLen: 2, caseSensitive: false };
+var DEFATT = { maxMatch: 5, minPatLen: 2, caseSensitive: false, triggerKeyCombination: "^ " };
 
 /** 
  * Struct for generic Completion Templates.
@@ -76,6 +76,37 @@ var Template = function( pat, filter, mask, field, start, end  ) {
 var OptCompletion = function( title, str ) {
     this.title = title;
     this.str = str;
+};
+
+var keyMatchGenerator = function(combination) {
+	let singleMatchGenerator = function(character) {
+		if (character === '^') {
+			return event => event.ctrlKey;
+		}
+		else if (character === '+') {
+			return event => event.shiftKey;
+		}
+		else if (character === '!') {
+			return event => event.altKey;
+		}
+		else {
+			return event => (event.keyCode || event.which) === character.charCodeAt(0);
+		}
+	};
+
+	let matchers = [];
+	for (let i = 0; i < combination.length; i++) {
+		matchers.push(singleMatchGenerator(combination[i]));
+	}
+
+	return event => {
+		for (let i = 0; i < matchers.length; i++) {
+			if (!matchers[i](event)) {
+				return false;
+			}
+		}
+		return true;
+	};
 };
 
 /**
@@ -105,7 +136,8 @@ var OptCompletion = function( title, str ) {
     // maximum nb of match displayed
     this._maxMatch     = param.configuration.maxMatch || DEFATT.maxMatch;   
     this._minPatLen    = param.configuration.minPatLen || DEFATT.minPatLen;
-    this._caseSensitive= param.configuration.caseSensitive || DEFATT.caseSensitive;
+	this._caseSensitive= param.configuration.caseSensitive || DEFATT.caseSensitive;
+	this._triggerKeyMatcher = keyMatchGenerator(param.configuration.triggerKeyCombination || DEFATT.triggerKeyCombination);
     /** Input information */
     this._lastChar = "";
     this._hasInput = false;
@@ -305,11 +337,6 @@ Completion.prototype.handleInput = function(event) {
     this._hasInput = true;
     //DEBUG console.log( "__INPUT hasI="+this._hasInput );
 };
-
-Completion.prototype.isCompletionTriggered = function(event) {
-	let key = event.keyCode || event.which;
-	return key === 32 && event.ctrlKey && event.shiftKey;
-};
 	
 /**
  * Set _lastChar, detects CTRL+SPACE.
@@ -325,7 +352,7 @@ Completion.prototype.handleKeypress = function(event) {
     //DEBUG this._logStatus( "KEYPRESS" );
     
     // Detect Ctrl+Space
-    if( this.isCompletionTriggered(event) && this._state === "VOID" ) {
+    if( this._triggerKeyMatcher(event) && this._state === "VOID" ) {
 	//Find a proper Template
 	// first from which we can extract a pattern
 	if( this._template === undefined ) {

--- a/plugin/usage.tid
+++ b/plugin/usage.tid
@@ -9,6 +9,7 @@ In the `configuration` object you can set :
 * `caseSensitive`: `true`/`false` (is search case sensitive ?)
 * `maxMatch` : an `integer` (max number of match displayed)
 * `minPatLength` : an `integer` (minimal length of a pattern to trigger completion search)
+* `triggerKeyCombination ` : a `string` representing the key combination that triggers the autocompletion popup. To use modifier keys in your combination, use following conversions : `ctrl` -> `^`, `alt` -> `!`, `shift` -> `+`. Note: ` ` (literally a whitespace) represents the `space` key.
 
 In the `template` array you can specify the various completion templates that will be used. Every template can have the following members.
 


### PR DESCRIPTION
Resolves #9.

This branch allows a user to define a trigger key combination. When the keys in this combination are pressed by the user, the auto-completion candidate list shows. In this way, users having difficulties for triggering the candidate list automatically can force the list to show manually.