### PR TITLE
Do not allow framed engine to propagate keydown events we have handled

### DIFF
--- a/plugin/files/completion.js
+++ b/plugin/files/completion.js
@@ -120,6 +120,16 @@ var keyMatchGenerator = function(combination) {
 	var Completion = function( editWidget, areaNode, param, sibling, offTop, offLeft ) {
 	console.log( "==Completion::creation" );
 
+	//check if the widget uses the framed engine
+	if(typeof sibling !== 'undefined') {
+		//The framed engine propagates all keydown events to the parent document
+		//Disable this and only propagate keydown events not handled by the autocompletion in our handleKeydown method
+		editWidget._original_handleKeydownEvent = editWidget.handleKeydownEvent;
+		editWidget.handleKeydownEvent = function(event) {
+			return false;
+		};
+	}
+
     // About underlying Widget
     this._widget = editWidget;
 	this._areaNode = areaNode;
@@ -349,15 +359,20 @@ Completion.prototype.handleKeydown = function(event) {
     	event.stopPropagation();
     }
     // ESC while selecting
-    if( (this._state === "PATTERN" || this._state === "SELECT") && key === 27 ) {
+    else if( (this._state === "PATTERN" || this._state === "SELECT") && key === 27 ) {
     	event.preventDefault();
     	event.stopPropagation();
     }
     // UP/DOWN while a pattern is extracted
-    if( (key===38 || key===40) && 
+    else if( (key===38 || key===40) && 
 	(this._state === "PATTERN" || this._state === "SELECT") ) {
-	event.preventDefault();
-    }
+		event.preventDefault();
+    } else {
+		//If we have not handled the keydown event, allow the widget to propagate it to the parent document
+		if(this._widget._original_handleKeydownEvent) {
+			this._widget._original_handleKeydownEvent(event);
+		}
+	}
 };
 /**
  * Means that something has been added/deleted => set _hasInput


### PR DESCRIPTION
By default the framed engine (which is in an iframe) propagates all keyboard events to the parent document. This is problematic for events handled by the autocompletion. For example, using the ESC key to cancel the autocomplete popup also triggers the dialog to cancel editing the tiddler. 

With this PR we override the default handleKeyDownEvent method of the framed engine, and only call it for events that we have not handled in the autocompletion.